### PR TITLE
Add ReusableSchema interface to validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ $operation = new \OpenAPIValidation\PSR7\OperationAddress('/password/gen', 'get'
 $validator->validate($operation, $request);
 ```
 
+### Reuse Schema After Validation
+
+`\OpenAPIValidation\PSR7\ValidatorBuilder` reads and compiles schema in memory as instance of `\cebe\openapi\spec\OpenApi`. Validators use this instance to perform validation logic. You can reuse this instance after the validation like this:
+
+```php
+$validator = (new \OpenAPIValidation\PSR7\ValidatorBuilder)->fromYamlFile($yamlFile)->getServerRequestValidator();
+# or
+$validator = (new \OpenAPIValidation\PSR7\ValidatorBuilder)->fromYamlFile($yamlFile)->getResponseValidator();
+
+/** @var \cebe\openapi\spec\OpenApi */
+$openApi = $validator->getSchema();
+```
+
 ### Request Message
 `\Psr\Http\Message\RequestInterface` validation is not implemented. 
 

--- a/src/PSR7/ResponseValidator.php
+++ b/src/PSR7/ResponseValidator.php
@@ -15,7 +15,7 @@ use OpenAPIValidation\PSR7\Validators\Headers;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
-class ResponseValidator
+class ResponseValidator implements ReusableSchema
 {
     /** @var OpenApi */
     protected $openApi;
@@ -26,6 +26,11 @@ class ResponseValidator
     {
         $this->openApi = $schema;
         $this->finder  = new SpecFinder($this->openApi);
+    }
+
+    public function getSchema() : OpenApi
+    {
+        return $this->openApi;
     }
 
     public function validate(OperationAddress $opAddr, ResponseInterface $response) : void

--- a/src/PSR7/ReusableSchema.php
+++ b/src/PSR7/ReusableSchema.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPIValidation\PSR7;
+
+use cebe\openapi\spec\OpenApi;
+
+interface ReusableSchema
+{
+    public function getSchema() : OpenApi;
+}

--- a/src/PSR7/ServerRequestValidator.php
+++ b/src/PSR7/ServerRequestValidator.php
@@ -37,7 +37,7 @@ use function json_encode;
 use function property_exists;
 use function strtolower;
 
-class ServerRequestValidator
+class ServerRequestValidator implements ReusableSchema
 {
     /** @var OpenApi */
     protected $openApi;
@@ -48,6 +48,11 @@ class ServerRequestValidator
     {
         $this->openApi = $schema;
         $this->finder  = new SpecFinder($this->openApi);
+    }
+
+    public function getSchema() : OpenApi
+    {
+        return $this->openApi;
     }
 
     /**


### PR DESCRIPTION
Solves issues from #23 

Basically, a developer can access compiled OpenAPI schema after validation is done.