### PR TITLE
#28 avoid response body validation if no “content” expectations set

### DIFF
--- a/src/PSR7/ResponseValidator.php
+++ b/src/PSR7/ResponseValidator.php
@@ -58,6 +58,11 @@ class ResponseValidator implements ReusableSchema
         }
 
         // 2. Validate Body
+        if (! $spec->content) {
+            // edge case: if "content" keyword is not set (body can be anything as no expectations set)
+            return;
+        }
+
         try {
             $bodyValidator = new Body();
             $bodyValidator->validate($response, $spec->content);

--- a/tests/PSR7/ValidateResponseTest.php
+++ b/tests/PSR7/ValidateResponseTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenAPIValidationTests\PSR7;
 
+use GuzzleHttp\Psr7\Response;
 use OpenAPIValidation\PSR7\Exception\Response\MissedResponseHeader;
 use OpenAPIValidation\PSR7\Exception\Response\ResponseBodyMismatch;
 use OpenAPIValidation\PSR7\Exception\Response\ResponseHeadersMismatch;
@@ -84,5 +85,15 @@ final class ValidateResponseTest extends BaseValidatorTest
             $this->assertEquals($addr->method(), $e->addr()->method());
             $this->assertEquals($response->getStatusCode(), $e->addr()->responseCode());
         }
+    }
+
+    public function testItValidatesEmptyBodyResponseGreen() : void
+    {
+        $addr     = new OperationAddress('/empty', 'post');
+        $response = new Response(204); // no body response
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getResponseValidator();
+        $validator->validate($addr, $response);
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/stubs/api.yaml
+++ b/tests/stubs/api.yaml
@@ -119,3 +119,9 @@ paths:
               schema:
                 type: string
                 format: binary
+  /empty:
+    post:
+      description: Get empty response
+      responses:
+        204:
+          description: No content


### PR DESCRIPTION
This PR will stop response validation if the schema has no "content" expectations like this:
```
  /empty:
    post:
      description: Get empty response
      responses:
        204:
          description: No content
```