### PR TITLE
Implementation of OpenAPI "default" response

### DIFF
--- a/src/PSR7/SpecFinder.php
+++ b/src/PSR7/SpecFinder.php
@@ -60,6 +60,11 @@ final class SpecFinder
         $operation = $this->findOperationSpec($addr->getOperationAddress());
 
         $response = $operation->responses->getResponse($addr->responseCode());
+
+        if (! $response) {
+            $response = $operation->responses->getResponse('default');
+        }
+
         if (! $response) {
             throw NoResponseCode::fromPathAndMethodAndResponseCode(
                 $addr->path(),

--- a/tests/PSR7/ValidateResponseTest.php
+++ b/tests/PSR7/ValidateResponseTest.php
@@ -96,4 +96,14 @@ final class ValidateResponseTest extends BaseValidatorTest
         $validator->validate($addr, $response);
         $this->addToAssertionCount(1);
     }
+
+    public function testItValidatesDefaultBodyResponseGreen() : void
+    {
+        $addr     = new OperationAddress('/empty', 'patch'); // "patch" contains "default" response definition
+        $response = new Response(404); // dummy any status code
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getResponseValidator();
+        $validator->validate($addr, $response);
+        $this->addToAssertionCount(1);
+    }
 }

--- a/tests/stubs/api.yaml
+++ b/tests/stubs/api.yaml
@@ -125,3 +125,8 @@ paths:
       responses:
         204:
           description: No content
+    patch:
+      summary: Empty response body for all response statuses
+      responses:
+        default:
+          description: No content


### PR DESCRIPTION
> “Default” means this response is used for all HTTP codes that are not covered individually for this operation.

https://swagger.io/docs/specification/describing-responses/#default

It was already allowed in \cebe\openapi\spec\Responses::__construct, but ignored by openapi-psr7-validator