### PR TITLE
Fix PathFinder returning the same operation multiple times

### DIFF
--- a/src/PSR7/PathFinder.php
+++ b/src/PSR7/PathFinder.php
@@ -78,6 +78,7 @@ class PathFinder
 
                 // path matched!
                 $paths[] = $opCandidate['addr'];
+                break;
             }
         }
 

--- a/tests/PSR7/PathFinderTest.php
+++ b/tests/PSR7/PathFinderTest.php
@@ -89,4 +89,32 @@ SPEC;
         $this->assertCount(1, $opAddrs);
         $this->assertEquals('/products/{id}', $opAddrs[0]->path());
     }
+
+    public function testItFindsMatchingOperationForMultipleServersWithSamePath() : void
+    {
+        $spec = <<<SPEC
+openapi: "3.0.0"
+info:
+  title: Uber API
+  description: Move your app forward with the Uber API
+  version: "1.0.0"
+servers:
+  - url: https://localhost/v1
+  - url: https://staging.example.com/v1
+  - url: https://prod.example.com/v1
+paths:
+  /products/{id}:
+    get:
+      summary: Product Types
+  /products/{review}:
+    post:
+      summary: Product Types
+SPEC;
+
+        $pathFinder = new PathFinder(Reader::readFromYaml($spec), new Uri('https://localhost/v1/products/10'), 'get');
+        $opAddrs    = $pathFinder->search();
+
+        $this->assertCount(1, $opAddrs);
+        $this->assertEquals('/products/{id}', $opAddrs[0]->path());
+    }
 }


### PR DESCRIPTION
When there are multiple servers with the same relative path, the PathFinder returns the same operation multiple times. This has the downside, that validation errors are no longer explained and a generic exception is thrown: 
```
The given request matched these operations: [/example,post],[/example,post],[example,post]. However, it matched not a single schema of theirs.
```

This PR fixes this and ensures that every path is returned only once.