### PR TITLE
Routed request validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,22 @@ $validator = (new \OpenAPIValidation\PSR7\ValidatorBuilder)->fromJsonFile($jsonF
 $schema = new \cebe\openapi\spec\OpenApi(); // generate schema object by hand
 $validator = (new \OpenAPIValidation\PSR7\ValidatorBuilder)->fromSchema($schema)->getServerRequestValidator();
 
-$validator->validate($request);
+$match = $validator->validate($request);
 ```
+
+As a result you would get and `OperationAddress $match` which has matched the given request. If you already know
+the operation which should match your request (i.e you have routing in your project), you can use 
+`RouterRequestValidator`
+
+```php
+$address = new \OpenAPIValidation\PSR7\OperationAddress('/some/operation', 'post');
+
+$validator = (new \OpenAPIValidation\PSR7\ValidatorBuilder)->fromSchema($schema)->getRoutedRequestValidator();
+
+$validator->validate($address, $request);
+```
+
+This would simplify validation a lot and give you more performance.
 
 ### Response Message
 Validation of `\Psr\Http\Message\ResponseInterface` is a bit more complicated

--- a/src/PSR7/RoutedServerRequestValidator.php
+++ b/src/PSR7/RoutedServerRequestValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPIValidation\PSR7;
+
+use cebe\openapi\spec\OpenApi;
+use OpenAPIValidation\PSR7\Exception\ValidationFailed;
+use OpenAPIValidation\PSR7\Validators\BodyValidator;
+use OpenAPIValidation\PSR7\Validators\CookiesValidator;
+use OpenAPIValidation\PSR7\Validators\HeadersValidator;
+use OpenAPIValidation\PSR7\Validators\PathValidator;
+use OpenAPIValidation\PSR7\Validators\QueryArgumentsValidator;
+use OpenAPIValidation\PSR7\Validators\SecurityValidator;
+use OpenAPIValidation\PSR7\Validators\ValidatorChain;
+use Psr\Http\Message\ServerRequestInterface;
+
+class RoutedServerRequestValidator implements ReusableSchema
+{
+    /** @var OpenApi */
+    protected $openApi;
+    /** @var MessageValidator */
+    protected $validator;
+
+    public function __construct(OpenApi $schema)
+    {
+        $this->openApi   = $schema;
+        $finder          = new SpecFinder($this->openApi);
+        $this->validator = new ValidatorChain(
+            new HeadersValidator($finder),
+            new CookiesValidator($finder),
+            new BodyValidator($finder),
+            new QueryArgumentsValidator($finder),
+            new PathValidator($finder),
+            new SecurityValidator($finder)
+        );
+    }
+
+    public function getSchema() : OpenApi
+    {
+        return $this->openApi;
+    }
+
+    /**
+     * @throws ValidationFailed
+     */
+    public function validate(OperationAddress $opAddr, ServerRequestInterface $serverRequest) : void
+    {
+        $this->validator->validate($opAddr, $serverRequest);
+    }
+}

--- a/src/PSR7/ValidatorBuilder.php
+++ b/src/PSR7/ValidatorBuilder.php
@@ -112,6 +112,16 @@ class ValidatorBuilder
         return new ServerRequestValidator($schema);
     }
 
+    public function getResponseValidator() : ResponseValidator
+    {
+        return new ResponseValidator($this->getOrCreateSchema());
+    }
+
+    public function getRoutedRequestValidator() : RoutedServerRequestValidator
+    {
+        return new RoutedServerRequestValidator($this->getOrCreateSchema());
+    }
+
     protected function getOrCreateSchema() : OpenApi
     {
         // Make cache dependency optional for end user
@@ -150,10 +160,5 @@ class ValidatorBuilder
         }
 
         return $this->factory->getCacheKey();
-    }
-
-    public function getResponseValidator() : ResponseValidator
-    {
-        return new ResponseValidator($this->getOrCreateSchema());
     }
 }

--- a/tests/PSR7/RoutedServerRequestTest.php
+++ b/tests/PSR7/RoutedServerRequestTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPIValidationTests\PSR7;
+
+use OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
+use OpenAPIValidation\PSR7\OperationAddress;
+use OpenAPIValidation\PSR7\ValidatorBuilder;
+use function GuzzleHttp\Psr7\stream_for;
+use function json_encode;
+
+final class RoutedServerRequestTest extends BaseValidatorTest
+{
+    public function testItValidatesMessageGreen() : void
+    {
+        $request = $this->makeGoodServerRequest('/path1', 'get');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getRoutedRequestValidator();
+        $validator->validate(new OperationAddress('/path1', 'get'), $request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testItValidatesBodyGreen() : void
+    {
+        $body    = ['name' => 'Alex'];
+        $request = $this->makeGoodServerRequest('/request-body', 'post')
+            ->withBody(stream_for(json_encode($body)));
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getRoutedRequestValidator();
+        $validator->validate(new OperationAddress('/request-body', 'post'), $request);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testItValidatesBodyHasInvalidPayloadRed() : void
+    {
+        $addr    = new OperationAddress('/request-body', 'post');
+        $body    = ['name' => 1000];
+        $request = $this->makeGoodServerRequest($addr->path(), $addr->method())
+            ->withBody(stream_for(json_encode($body)));
+
+        $this->expectException(InvalidBody::class);
+        $this->expectExceptionMessage(
+            'Body does not match schema for content-type "application/json" for Request [post /request-body]'
+        );
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getRoutedRequestValidator();
+        $validator->validate(new OperationAddress('/request-body', 'post'), $request);
+    }
+
+    public function testItValidatesBodyHasUnexpectedTypeRed() : void
+    {
+        $addr    = new OperationAddress('/request-body', 'post');
+        $request = $this->makeGoodServerRequest($addr->path(), $addr->method())
+            ->withoutHeader('Content-Type')
+            ->withHeader('Content-Type', 'unexpected/content');
+
+        $this->expectException(InvalidHeaders::class);
+        $this->expectExceptionMessage(
+            'Content-Type "unexpected/content" is not expected for Request [post /request-body]'
+        );
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getRoutedRequestValidator();
+        $validator->validate(new OperationAddress('/request-body', 'post'), $request);
+    }
+
+    public function testItValidatesMessageWrongHeaderValueRed() : void
+    {
+        $addr    = new OperationAddress('/path1', 'get');
+        $request = $this->makeGoodServerRequest($addr->path(), $addr->method())->withHeader('Header-A', 'wrong value');
+
+        $this->expectException(InvalidHeaders::class);
+        $this->expectExceptionMessage('Value "wrong value" for header "Header-A" is invalid for Request [get /path1]');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getRoutedRequestValidator();
+        $validator->validate(new OperationAddress('/path1', 'get'), $request);
+    }
+
+    public function testItValidatesMessageMissedHeaderRed() : void
+    {
+        $addr    = new OperationAddress('/path1', 'get');
+        $request = $this->makeGoodServerRequest($addr->path(), $addr->method())->withoutHeader('Header-A');
+
+        $this->expectException(InvalidHeaders::class);
+        $this->expectExceptionMessage('Missing required header "Header-A" for Request [get /path1]');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($this->apiSpecFile)->getRoutedRequestValidator();
+        $validator->validate(new OperationAddress('/path1', 'get'), $request);
+    }
+}


### PR DESCRIPTION
Fixes #17 

Simplifies a lot ServerRequestValidator in case of `OperationAddress` is provided explicitly by external user. This might be some framework module to incorporate this library (i.e Symfony bundle).