### PR TITLE
44 improve body multipart validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         {
             "name": "Dmitry Lezhnev",
             "email": "lezhnev.work@gmail.com",
-            "homepage": "https://lessthan12ms.com",
+            "homepage": "https://github.com/lezhnev74/openapi-psr7-validator",
             "role": "Developer"
         }
     ],
@@ -35,7 +35,8 @@
         "psr/cache": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "respect/validation": "^1.1"
+        "respect/validation": "^1.1",
+        "riverline/multipart-parser": "dev-master"
     },
     "require-dev": {
         "cache/array-adapter": "^1.0",
@@ -46,5 +47,11 @@
     "config": {
         "sort-packages": true
     },
-    "prefer-stable": true
+    "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/lezhnev74/multipart-parser"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "respect/validation": "^1.1",
-        "riverline/multipart-parser": "dev-master"
+        "riverline/multipart-parser": "^2.0.3"
     },
     "require-dev": {
         "cache/array-adapter": "^1.0",
@@ -47,11 +47,5 @@
     "config": {
         "sort-packages": true
     },
-    "prefer-stable": true,
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/lezhnev74/multipart-parser"
-        }
-    ]
+    "prefer-stable": true
 }

--- a/src/PSR7/Exception/Validation/AddressValidationFailed.php
+++ b/src/PSR7/Exception/Validation/AddressValidationFailed.php
@@ -17,9 +17,9 @@ abstract class AddressValidationFailed extends ValidationFailed
     /**
      * @return static
      */
-    public static function fromAddrAndPrev(OperationAddress $address, Throwable $prev) : self
+    public static function fromAddrAndPrev(OperationAddress $address, ?Throwable $prev) : self
     {
-        $ex          = new static(sprintf('Validation failed for %s', $address), $prev->getCode(), $prev);
+        $ex          = new static(sprintf('Validation failed for %s', $address), $prev ? $prev->getCode() : 0, $prev);
         $ex->address = $address;
 
         return $ex;

--- a/src/PSR7/Exception/Validation/InvalidBody.php
+++ b/src/PSR7/Exception/Validation/InvalidBody.php
@@ -21,6 +21,23 @@ class InvalidBody extends AddressValidationFailed
         return $exception;
     }
 
+    public static function becauseBodyPartDoesNotMatchSchema(
+        string $partName,
+        string $contentType,
+        OperationAddress $addr,
+        ?SchemaMismatch $prev = null
+    ) : self {
+        $exception          = static::fromAddrAndPrev($addr, $prev);
+        $exception->message = sprintf(
+            'Multipart body does not match schema for part %s with content-type "%s" for %s',
+            $partName,
+            $contentType,
+            $addr
+        );
+
+        return $exception;
+    }
+
     public static function becauseBodyIsNotValidJson(string $error, OperationAddress $addr) : self
     {
         $exception          = static::fromAddr($addr);

--- a/src/PSR7/Exception/Validation/InvalidBody.php
+++ b/src/PSR7/Exception/Validation/InvalidBody.php
@@ -21,7 +21,7 @@ class InvalidBody extends AddressValidationFailed
         return $exception;
     }
 
-    public static function becauseBodyPartDoesNotMatchSchema(
+    public static function becauseBodyDoesNotMatchSchemaMultipart(
         string $partName,
         string $contentType,
         OperationAddress $addr,
@@ -29,7 +29,7 @@ class InvalidBody extends AddressValidationFailed
     ) : self {
         $exception          = static::fromAddrAndPrev($addr, $prev);
         $exception->message = sprintf(
-            'Multipart body does not match schema for part %s with content-type "%s" for %s',
+            'Multipart body does not match schema for part "%s" with content-type "%s" for %s',
             $partName,
             $contentType,
             $addr

--- a/src/PSR7/Exception/Validation/InvalidHeaders.php
+++ b/src/PSR7/Exception/Validation/InvalidHeaders.php
@@ -18,10 +18,34 @@ class InvalidHeaders extends AddressValidationFailed
         return $exception;
     }
 
+    public static function becauseOfMissingRequiredHeaderMupripart(
+        string $partName,
+        string $headerName,
+        OperationAddress $address
+    ) : self {
+        $exception          = static::fromAddr($address);
+        $exception->message = sprintf('Missing required header "%s" for %s in multipart "%s"', $headerName, $address, $partName);
+
+        return $exception;
+    }
+
     public static function becauseValueDoesNotMatchSchema(string $headerName, string $headerValue, OperationAddress $address, SchemaMismatch $prev) : self
     {
         $exception          = static::fromAddrAndPrev($address, $prev);
         $exception->message = sprintf('Value "%s" for header "%s" is invalid for %s', $headerValue, $headerName, $address);
+
+        return $exception;
+    }
+
+    public static function becauseValueDoesNotMatchSchemaMultipart(
+        string $partName,
+        string $headerName,
+        string $headerValue,
+        OperationAddress $address,
+        SchemaMismatch $prev
+    ) : self {
+        $exception          = static::fromAddrAndPrev($address, $prev);
+        $exception->message = sprintf('Value "%s" for header "%s" is invalid for "%s" in multipart "%s"', $headerValue, $headerName, $address, $partName);
 
         return $exception;
     }

--- a/src/PSR7/ResponseValidator.php
+++ b/src/PSR7/ResponseValidator.php
@@ -6,7 +6,7 @@ namespace OpenAPIValidation\PSR7;
 
 use cebe\openapi\spec\OpenApi;
 use OpenAPIValidation\PSR7\Exception\ValidationFailed;
-use OpenAPIValidation\PSR7\Validators\BodyValidator;
+use OpenAPIValidation\PSR7\Validators\BodyValidator\BodyValidator;
 use OpenAPIValidation\PSR7\Validators\HeadersValidator;
 use OpenAPIValidation\PSR7\Validators\ValidatorChain;
 use Psr\Http\Message\ResponseInterface;

--- a/src/PSR7/RoutedServerRequestValidator.php
+++ b/src/PSR7/RoutedServerRequestValidator.php
@@ -6,7 +6,7 @@ namespace OpenAPIValidation\PSR7;
 
 use cebe\openapi\spec\OpenApi;
 use OpenAPIValidation\PSR7\Exception\ValidationFailed;
-use OpenAPIValidation\PSR7\Validators\BodyValidator;
+use OpenAPIValidation\PSR7\Validators\BodyValidator\BodyValidator;
 use OpenAPIValidation\PSR7\Validators\CookiesValidator;
 use OpenAPIValidation\PSR7\Validators\HeadersValidator;
 use OpenAPIValidation\PSR7\Validators\PathValidator;

--- a/src/PSR7/ServerRequestValidator.php
+++ b/src/PSR7/ServerRequestValidator.php
@@ -8,7 +8,7 @@ use cebe\openapi\spec\OpenApi;
 use OpenAPIValidation\PSR7\Exception\MultipleOperationsMismatchForRequest;
 use OpenAPIValidation\PSR7\Exception\NoOperation;
 use OpenAPIValidation\PSR7\Exception\ValidationFailed;
-use OpenAPIValidation\PSR7\Validators\BodyValidator;
+use OpenAPIValidation\PSR7\Validators\BodyValidator\BodyValidator;
 use OpenAPIValidation\PSR7\Validators\CookiesValidator;
 use OpenAPIValidation\PSR7\Validators\HeadersValidator;
 use OpenAPIValidation\PSR7\Validators\PathValidator;

--- a/src/PSR7/Validators/BodyValidator.php
+++ b/src/PSR7/Validators/BodyValidator.php
@@ -4,21 +4,34 @@ declare(strict_types=1);
 
 namespace OpenAPIValidation\PSR7\Validators;
 
+use cebe\openapi\spec\Header;
+use cebe\openapi\spec\MediaType;
+use cebe\openapi\spec\Type as CebeType;
+use OpenAPIValidation\PSR7\Exception\NoPath;
 use OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
 use OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
 use OpenAPIValidation\PSR7\MessageValidator;
 use OpenAPIValidation\PSR7\OperationAddress;
 use OpenAPIValidation\PSR7\SpecFinder;
 use OpenAPIValidation\Schema\Exception\SchemaMismatch;
+use OpenAPIValidation\Schema\Exception\TypeMismatch;
 use OpenAPIValidation\Schema\SchemaValidator;
 use Psr\Http\Message\MessageInterface;
+use Riverline\MultiPartParser\Converters\PSR7;
+use Riverline\MultiPartParser\StreamedPart;
+use RuntimeException;
 use const JSON_ERROR_NONE;
 use function json_decode;
 use function json_last_error;
 use function json_last_error_msg;
 use function preg_match;
+use function sprintf;
 use function strtok;
 
+/**
+ * Supports validation for different media types of bodies,
+ * including JSON and multipart types
+ */
 final class BodyValidator implements MessageValidator
 {
     private const HEADER_CONTENT_TYPE = 'Content-Type';
@@ -32,7 +45,11 @@ final class BodyValidator implements MessageValidator
         $this->finder = $finder;
     }
 
-    /** {@inheritdoc} */
+    /**
+     * @throws InvalidBody
+     * @throws InvalidHeaders
+     * @throws NoPath
+     */
     public function validate(OperationAddress $addr, MessageInterface $message) : void
     {
         $mediaTypeSpecs = $this->finder->findBodySpec($addr);
@@ -42,6 +59,27 @@ final class BodyValidator implements MessageValidator
             return;
         }
 
+        $contentType = $this->readContentType($addr, $message);
+
+        // does the response contain one of described media types?
+        if (! isset($mediaTypeSpecs[$contentType])) {
+            throw InvalidHeaders::becauseContentTypeIsNotExpected($contentType, $addr);
+        }
+        $schema = $mediaTypeSpecs[$contentType]->schema;
+        if (! $schema) {
+            return;
+        }
+
+        // Prepare data for validation
+        if (preg_match('#^multipart/.*#', $contentType)) {
+            $this->validateMultipart($addr, $message, $mediaTypeSpecs, $contentType);
+        } else {
+            $this->validateUnipart($addr, $message, $schema, $contentType);
+        }
+    }
+
+    private function readContentType(OperationAddress $addr, MessageInterface $message) : string
+    {
         $contentTypes = $message->getHeader(self::HEADER_CONTENT_TYPE);
         if (! $contentTypes) {
             throw InvalidHeaders::becauseOfMissingRequiredHeader(self::HEADER_CONTENT_TYPE, $addr);
@@ -54,24 +92,128 @@ final class BodyValidator implements MessageValidator
         // Other parameters SHOULD be skipped
         $contentType = strtok($contentType, ';');
 
-        // does the response contain one of described media types?
-        if (! isset($mediaTypeSpecs[$contentType])) {
-            throw InvalidHeaders::becauseContentTypeIsNotExpected($contentType, $addr);
+        return $contentType;
+    }
+
+    /**
+     * @see https://swagger.io/docs/specification/describing-request-body/multipart-requests/
+     *
+     * @param MediaType[] $mediaTypeSpecs
+     */
+    private function validateMultipart(OperationAddress $addr, MessageInterface $message, array $mediaTypeSpecs, string $contentType) : void
+    {
+        $schema = $mediaTypeSpecs[$contentType]->schema;
+
+        // 0. Multipart body message MUST be described with a set of object properties
+        if ($schema->type !== CebeType::OBJECT) {
+            throw TypeMismatch::becauseTypeDoesNotMatch('object', $schema->type);
         }
 
-        // ok looks good, now apply validation
-        $body = (string) $message->getBody();
+        // 1. Parse message body
+        $document = PSR7::convert($message);
 
-        if (preg_match('#^application/.*json$#', $contentType)) {
-            $body = json_decode($body, true);
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                throw InvalidBody::becauseBodyIsNotValidJson(json_last_error_msg(), $addr);
-            }
-        }
+        // 2. Validate bodies of each part
+        $body = $this->prepareMultipartData($addr, $document);
 
         $validator = new SchemaValidator($this->detectValidationStrategy($message));
         try {
-            $validator->validate($body, $mediaTypeSpecs[$contentType]->schema);
+            $validator->validate($body, $schema);
+        } catch (SchemaMismatch $e) {
+            throw InvalidBody::becauseBodyDoesNotMatchSchema($contentType, $addr, $e);
+        }
+
+        // 3. Validate specified part encodings and headers
+        $encodings = $mediaTypeSpecs[$contentType]->encoding;
+
+        foreach ($encodings as $name => $encoding) {
+            $parts = $document->getPartsByName($name);
+            if (! $parts) {
+                throw new RuntimeException(sprintf(
+                    'SPecified body part %s is not found',
+                    $name
+                ));
+            }
+
+            foreach ($parts as $part) {
+                // 3.1 parts encoding
+                $partContentType = $part->getHeader(self::HEADER_CONTENT_TYPE);
+                if ($encoding->contentType !== $partContentType) {
+                    throw InvalidBody::becauseBodyPartDoesNotMatchSchema(
+                        $name,
+                        $partContentType,
+                        $addr
+                    );
+                }
+
+                // 3.2. parts headers
+                foreach ($encoding->headers as $headerName => $header) {
+                    /** @var Header $header */
+                    $headerSchema = $header->schema;
+
+                    $validator = new SchemaValidator($this->detectValidationStrategy($message));
+                    try {
+                        $validator->validate($body, $schema);
+                    } catch (SchemaMismatch $e) {
+                        throw InvalidBody::becauseBodyDoesNotMatchSchema($contentType, $addr, $e);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Prepare a Multipart message body (a set of normal parts) for validation against a schema
+     *
+     * @see https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
+     * @see https://swagger.io/docs/specification/describing-request-body/multipart-requests/
+     *
+     * @return mixed[]
+     *
+     * @throws InvalidBody
+     * @throws TypeMismatch
+     */
+    private function prepareMultipartData(OperationAddress $addr, StreamedPart $document) : array
+    {
+        $multipartData = []; // a buffer to fill up with message parts
+        foreach ($document->getParts() as $i => $part) {
+            $partContentType = $part->getHeader('Content-Type');
+
+            if (preg_match('#^application/.*json$#', $partContentType)) {
+                $partBody = json_decode($part->getBody(), true);
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    throw InvalidBody::becauseBodyIsNotValidJson(json_last_error_msg(), $addr);
+                }
+            } else {
+                $partBody = $part->getBody();
+            }
+
+            // if name is not set, it should be validated with "additionalProperties" keyword
+            $multipartData[$part->getName() ?? '____' . $i] = $partBody;
+        }
+
+        return $multipartData;
+    }
+
+    /**
+     * @param MediaType[] $mediaTypeSpecs
+     *
+     * @throws InvalidBody
+     */
+    private function validateUnipart(OperationAddress $addr, MessageInterface $message, array $mediaTypeSpecs, string $contentType) : void
+    {
+        if (preg_match('#^application/.*json$#', $contentType)) {
+            $body = json_decode((string) $message->getBody(), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw InvalidBody::becauseBodyIsNotValidJson(json_last_error_msg(), $addr);
+            }
+        } else {
+            $body = (string) $message->getBody();
+        }
+
+        $validator = new SchemaValidator($this->detectValidationStrategy($message));
+        $schema    = $mediaTypeSpecs[$contentType]->schema;
+        try {
+            $validator->validate($body, $schema);
         } catch (SchemaMismatch $e) {
             throw InvalidBody::becauseBodyDoesNotMatchSchema($contentType, $addr, $e);
         }

--- a/src/PSR7/Validators/BodyValidator/BodyValidator.php
+++ b/src/PSR7/Validators/BodyValidator/BodyValidator.php
@@ -25,6 +25,7 @@ final class BodyValidator implements MessageValidator
     use ValidationStrategy;
     use MultipartValidation;
     use UnipartValidation;
+    use FormUrlencodedValidation;
 
     /** @var SpecFinder */
     private $finder;
@@ -70,6 +71,8 @@ final class BodyValidator implements MessageValidator
         // Validate message body
         if (preg_match('#^multipart/.*#', $contentType)) {
             $this->validateMultipart($addr, $message, $mediaTypeSpecs, $contentType);
+        } elseif (preg_match('#^application/x-www-form-urlencoded$#', $contentType)) {
+            $this->validateFormUrlencoded($addr, $message, $mediaTypeSpecs, $contentType);
         } else {
             $this->validateUnipart($addr, $message, $mediaTypeSpecs, $contentType);
         }

--- a/src/PSR7/Validators/BodyValidator/BodyValidator.php
+++ b/src/PSR7/Validators/BodyValidator/BodyValidator.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPIValidation\PSR7\Validators\BodyValidator;
+
+use OpenAPIValidation\PSR7\Exception\NoPath;
+use OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
+use OpenAPIValidation\PSR7\MessageValidator;
+use OpenAPIValidation\PSR7\OperationAddress;
+use OpenAPIValidation\PSR7\SpecFinder;
+use OpenAPIValidation\PSR7\Validators\ValidationStrategy;
+use Psr\Http\Message\MessageInterface;
+use function preg_match;
+use function strtok;
+
+/**
+ * Supports validation for different media types of bodies,
+ * including JSON and multipart types
+ */
+final class BodyValidator implements MessageValidator
+{
+    private const HEADER_CONTENT_TYPE = 'Content-Type';
+    use ValidationStrategy;
+    use MultipartValidation;
+    use UnipartValidation;
+
+    /** @var SpecFinder */
+    private $finder;
+
+    public function __construct(SpecFinder $finder)
+    {
+        $this->finder = $finder;
+    }
+
+    /**
+     * @throws InvalidBody
+     * @throws InvalidHeaders
+     * @throws NoPath
+     */
+    public function validate(OperationAddress $addr, MessageInterface $message) : void
+    {
+        $mediaTypeSpecs = $this->finder->findBodySpec($addr);
+
+        if (empty($mediaTypeSpecs)) {
+            // edge case: if "content" keyword is not set (body can be anything as no expectations set)
+            return;
+        }
+
+        // Detect ContentType of the message
+        $contentType = $this->messageContentType($message);
+        if (! $contentType) {
+            throw InvalidHeaders::becauseOfMissingRequiredHeader(self::HEADER_CONTENT_TYPE, $addr);
+        }
+
+        // does the response contain one of described media types?
+        if (! isset($mediaTypeSpecs[$contentType])) {
+            throw InvalidHeaders::becauseContentTypeIsNotExpected($contentType, $addr);
+        }
+
+        // detect the schema for the media type
+        $schema = $mediaTypeSpecs[$contentType]->schema;
+        if (! $schema) {
+            // no schema means no validation
+            // note: schema is REQUIRED to define the input parameters to the operation when using multipart content
+            return;
+        }
+
+        // Validate message body
+        if (preg_match('#^multipart/.*#', $contentType)) {
+            $this->validateMultipart($addr, $message, $mediaTypeSpecs, $contentType);
+        } else {
+            $this->validateUnipart($addr, $message, $mediaTypeSpecs, $contentType);
+        }
+    }
+
+    private function messageContentType(MessageInterface $message) : ?string
+    {
+        $contentTypes = $message->getHeader(self::HEADER_CONTENT_TYPE);
+        if (! $contentTypes) {
+            return null;
+        }
+
+        $contentType = $contentTypes[0]; // use the first value
+
+        // As per https://tools.ietf.org/html/rfc7231#section-3.1.1.5 and https://tools.ietf.org/html/rfc7231#section-3.1.1.1
+        // ContentType can contain multiple statements (type/subtype + parameters), ie: 'multipart/form-data; charset=utf-8; boundary=__X_PAW_BOUNDARY__'
+        // OpenAPI Spec only defines the first part of the header value (type/subtype)
+        // Other parameters SHOULD be skipped
+        $contentType = strtok($contentType, ';');
+
+        return $contentType;
+    }
+}

--- a/src/PSR7/Validators/BodyValidator/FormUrlencodedValidation.php
+++ b/src/PSR7/Validators/BodyValidator/FormUrlencodedValidation.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPIValidation\PSR7\Validators\BodyValidator;
+
+use cebe\openapi\spec\MediaType;
+use cebe\openapi\spec\Schema;
+use cebe\openapi\spec\Type as CebeType;
+use OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use OpenAPIValidation\PSR7\OperationAddress;
+use OpenAPIValidation\Schema\Exception\SchemaMismatch;
+use OpenAPIValidation\Schema\Exception\TypeMismatch;
+use OpenAPIValidation\Schema\SchemaValidator;
+use Psr\Http\Message\MessageInterface;
+use function explode;
+
+/**
+ * Should validate "application/x-www-form-urlencoded" body types
+ */
+trait FormUrlencodedValidation
+{
+    /**
+     * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#requestBodyObject
+     *
+     * @param MediaType[] $mediaTypeSpecs
+     */
+    private function validateFormUrlencoded(OperationAddress $addr, MessageInterface $message, array $mediaTypeSpecs, string $contentType) : void
+    {
+        /** @var Schema $schema */
+        $schema = $mediaTypeSpecs[$contentType]->schema;
+
+        // 0. Multipart body message MUST be described with a set of object properties
+        if ($schema->type !== CebeType::OBJECT) {
+            throw TypeMismatch::becauseTypeDoesNotMatch('object', $schema->type);
+        }
+
+        // 1. Parse message body
+        $body = $this->parseUrlencodedData($message);
+
+        $validator = new SchemaValidator($this->detectValidationStrategy($message));
+        try {
+            $validator->validate($body, $schema);
+        } catch (SchemaMismatch $e) {
+            throw InvalidBody::becauseBodyDoesNotMatchSchema($contentType, $addr, $e);
+        }
+
+        // 3. Validate specified part encodings and headers
+        // @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#encoding-object
+        // The encoding object SHALL only apply to requestBody objects when the media type is multipart or application/x-www-form-urlencoded.
+        // An encoding attribute is introduced to give you control over the serialization of parts of multipart request bodies.
+        // This attribute is only applicable to "multipart" and "application/x-www-form-urlencoded" request bodies.
+        $encodings = $mediaTypeSpecs[$contentType]->encoding;
+
+        // todo URL Serialization:
+        // @see https://github.com/lezhnev74/openapi-psr7-validator/issues/47
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function parseUrlencodedData(MessageInterface $message) : array
+    {
+        $body = [];
+
+        foreach (explode('&', $message->getBody()->getContents()) as $chunk) {
+            [$name, $value] = explode('=', $chunk);
+            $body[$name]    = $value;
+        }
+
+        return $body;
+    }
+}

--- a/src/PSR7/Validators/BodyValidator/MultipartValidation.php
+++ b/src/PSR7/Validators/BodyValidator/MultipartValidation.php
@@ -54,7 +54,7 @@ trait MultipartValidation
         $document = PSR7::convert($message);
 
         // 2. Validate bodies of each part
-        $body = $this->prepareMultipartData($addr, $document);
+        $body = $this->parseMultipartData($addr, $document);
 
         $validator = new SchemaValidator($this->detectValidationStrategy($message));
         try {
@@ -136,7 +136,7 @@ trait MultipartValidation
      * @throws InvalidBody
      * @throws TypeMismatch
      */
-    private function prepareMultipartData(OperationAddress $addr, StreamedPart $document) : array
+    private function parseMultipartData(OperationAddress $addr, StreamedPart $document) : array
     {
         $multipartData = []; // a buffer to fill up with message parts
         foreach ($document->getParts() as $i => $part) {

--- a/src/PSR7/Validators/BodyValidator/UnipartValidation.php
+++ b/src/PSR7/Validators/BodyValidator/UnipartValidation.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPIValidation\PSR7\Validators\BodyValidator;
+
+use cebe\openapi\spec\MediaType;
+use OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use OpenAPIValidation\PSR7\OperationAddress;
+use OpenAPIValidation\Schema\Exception\SchemaMismatch;
+use OpenAPIValidation\Schema\SchemaValidator;
+use Psr\Http\Message\MessageInterface;
+use const JSON_ERROR_NONE;
+use function json_decode;
+use function json_last_error;
+use function json_last_error_msg;
+use function preg_match;
+
+trait UnipartValidation
+{
+    /**
+     * @param MediaType[] $mediaTypeSpecs
+     *
+     * @throws InvalidBody
+     */
+    private function validateUnipart(OperationAddress $addr, MessageInterface $message, array $mediaTypeSpecs, string $contentType) : void
+    {
+        if (preg_match('#^application/.*json$#', $contentType)) {
+            $body = json_decode((string) $message->getBody(), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw InvalidBody::becauseBodyIsNotValidJson(json_last_error_msg(), $addr);
+            }
+        } else {
+            $body = (string) $message->getBody();
+        }
+
+        $validator = new SchemaValidator($this->detectValidationStrategy($message));
+        $schema    = $mediaTypeSpecs[$contentType]->schema;
+        try {
+            $validator->validate($body, $schema);
+        } catch (SchemaMismatch $e) {
+            throw InvalidBody::becauseBodyDoesNotMatchSchema($contentType, $addr, $e);
+        }
+    }
+}

--- a/src/Schema/SchemaValidator.php
+++ b/src/Schema/SchemaValidator.php
@@ -126,7 +126,7 @@ final class SchemaValidator implements Validator
             }
 
             if (isset($schema->properties) && count($schema->properties)) {
-                $additionalProperties = $schema->additionalProperties ?? null;
+                $additionalProperties = $schema->additionalProperties ?? null; // defaults to true
                 (new Properties($schema, $this->validationStrategy, $breadCrumb))->validate($data, $schema->properties, $additionalProperties);
             }
 

--- a/src/Schema/TypeFormats/StringUUID.php
+++ b/src/Schema/TypeFormats/StringUUID.php
@@ -10,7 +10,7 @@ class StringUUID
 {
     public function __invoke(string $value) : bool
     {
-        $patternUUIDV4 = '/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i';
+        $patternUUIDV4 = '/^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}$/';
 
         return (bool) preg_match($patternUUIDV4, $value);
     }

--- a/tests/PSR7/Validators/BodyValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidatorTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAPIValidationTests\PSR7\Validators;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use OpenAPIValidation\PSR7\ValidatorBuilder;
+use OpenAPIValidation\Schema\Exception\FormatMismatch;
+use PHPUnit\Framework\TestCase;
+use function GuzzleHttp\Psr7\parse_request;
+
+class BodyValidatorTest extends TestCase
+{
+    /**
+     * @return array<array<string>> of arguments
+     */
+    public function dataProviderGreen() : array
+    {
+        return [
+            // Normal multipart message
+            [
+                <<<HTTP
+POST /multipart HTTP/1.1
+Content-Length: 428
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryOmz20xyMCkE27rN7
+
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="id"
+Content-Type: text/plain
+
+123e4567-e89b-12d3-a456-426655440000
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="address"
+Content-Type: application/json
+
+{
+  "street": "3, Garden St",
+  "city": "Hillsbery, UT"
+}
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="profileImage "; filename="image1.png"
+Content-Type: application/octet-steam
+
+{...file content...}
+------WebKitFormBoundaryOmz20xyMCkE27rN7--
+HTTP
+,
+            ],
+            // multiple files with the same part name (array of files)
+            [
+                <<<HTTP
+POST /multipart/files HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="fileName"; filename="file1.txt"
+Content-Type: text/plain
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="fileName"; filename="file2.png"
+Content-Type: image/png
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="fileName"; filename="file3.jpg"
+Content-Type: image/jpeg
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+            ],
+            // specified encoding for one part
+            [
+                <<<HTTP
+POST /multipart/encoding HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="image"; filename="file1.txt"
+Content-Type: specific/type
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+            ],
+            // specified headers for one part
+            [
+                <<<HTTP
+POST /multipart/encoding HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="image"; filename="file1.txt"
+Content-Type: specific/type
+X-Custom-Header: string value goes here
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<array<string,string>> of arguments
+     */
+    public function dataProviderRed() : array
+    {
+        return [
+            // wrong data in one of the parts
+            [
+                <<<HTTP
+POST /multipart HTTP/1.1
+Content-Length: 428
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryOmz20xyMCkE27rN7
+
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="id"
+Content-Type: text/plain
+
+wrong uuid
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="address"
+Content-Type: application/json
+
+{
+  "street": "3, Garden St",
+  "city": "Hillsbery, UT"
+}
+------WebKitFormBoundaryOmz20xyMCkE27rN7
+Content-Disposition: form-data; name="profileImage "; filename="image1.png"
+Content-Type: application/octet-steam
+
+{...file content...}
+------WebKitFormBoundaryOmz20xyMCkE27rN7--
+HTTP
+,
+                InvalidBody::class,
+            ],
+            // wrong encoding for one of the part
+            [
+                <<<HTTP
+POST /multipart/encoding HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="image"; filename="file1.txt"
+Content-Type: invalid/type
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+                InvalidBody::class,
+            ],
+            // wrong header for one part
+            [
+                <<<HTTP
+POST /multipart/encoding HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="image"; filename="file1.txt"
+Content-Type: specific/type
+X-Custom-Header-WRONG: string value goes here
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+                FormatMismatch::class,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderGreen
+     */
+    public function testValidateMultipartGreen(string $message) : void
+    {
+        $specFile = __DIR__ . '/../../stubs/multipart.yaml';
+
+        $request       = parse_request($message); // convert a text HTTP message to a PSR7 message
+        $serverRequest = new ServerRequest(
+            $request->getMethod(),
+            $request->getUri(),
+            $request->getHeaders(),
+            $request->getBody()
+        );
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($serverRequest);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider dataProviderRed
+     */
+    public function testValidateMultipartRed(string $message, string $expectedExceptionClass) : void
+    {
+        $this->expectException($expectedExceptionClass);
+
+        $specFile = __DIR__ . '/../../stubs/multipart.yaml';
+
+        $request       = parse_request($message); // convert a text HTTP message to a PSR7 message
+        $serverRequest = new ServerRequest(
+            $request->getMethod(),
+            $request->getUri(),
+            $request->getHeaders(),
+            $request->getBody()
+        );
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($serverRequest);
+    }
+}

--- a/tests/PSR7/Validators/BodyValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidatorTest.php
@@ -6,8 +6,8 @@ namespace OpenAPIValidationTests\PSR7\Validators;
 
 use GuzzleHttp\Psr7\ServerRequest;
 use OpenAPIValidation\PSR7\Exception\Validation\InvalidBody;
+use OpenAPIValidation\PSR7\Exception\Validation\InvalidHeaders;
 use OpenAPIValidation\PSR7\ValidatorBuilder;
-use OpenAPIValidation\Schema\Exception\FormatMismatch;
 use PHPUnit\Framework\TestCase;
 use function GuzzleHttp\Psr7\parse_request;
 
@@ -107,6 +107,22 @@ X-Custom-Header: string value goes here
 HTTP
 ,
             ],
+            // specified headers for one part (wildcard)
+            [
+                <<<HTTP
+POST /multipart/encoding/wildcard HTTP/1.1
+Content-Length: 2740
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ
+Content-Disposition: form-data; name="image"; filename="file1.txt"
+Content-Type: image/whatever
+
+[file content goes there]
+------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
+HTTP
+,
+            ],
         ];
     }
 
@@ -166,7 +182,7 @@ HTTP
             // wrong header for one part
             [
                 <<<HTTP
-POST /multipart/encoding HTTP/1.1
+POST /multipart/headers HTTP/1.1
 Content-Length: 2740
 Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryWfPNVh4wuWBlyEyQ
 
@@ -179,7 +195,7 @@ X-Custom-Header-WRONG: string value goes here
 ------WebKitFormBoundaryWfPNVh4wuWBlyEyQ--
 HTTP
 ,
-                FormatMismatch::class,
+                InvalidHeaders::class,
             ],
         ];
     }

--- a/tests/PSR7/Validators/BodyValidatorTest.php
+++ b/tests/PSR7/Validators/BodyValidatorTest.php
@@ -16,7 +16,7 @@ class BodyValidatorTest extends TestCase
     /**
      * @return array<array<string>> of arguments
      */
-    public function dataProviderGreen() : array
+    public function dataProviderMultipartGreen() : array
     {
         return [
             // Normal multipart message
@@ -127,9 +127,29 @@ HTTP
     }
 
     /**
+     * @return array<array<string>> of arguments
+     */
+    public function dataProviderFormUrlencodedGreen() : array
+    {
+        return [
+            // Normal message
+            [
+                <<<HTTP
+POST /urlencoded/scalar-types HTTP/1.1
+Content-Length: 428
+Content-Type: application/x-www-form-urlencoded; charset=utf-8
+
+address=Moscow%2C+ulitsa+Rusakova%2C+d.15&id=59731930-a95a-11e9-a2a3-2a2ae2dbcce4
+HTTP
+,
+            ],
+        ];
+    }
+
+    /**
      * @return array<array<string,string>> of arguments
      */
-    public function dataProviderRed() : array
+    public function dataProviderMultipartRed() : array
     {
         return [
             // wrong data in one of the parts
@@ -201,7 +221,7 @@ HTTP
     }
 
     /**
-     * @dataProvider dataProviderGreen
+     * @dataProvider dataProviderMultipartGreen
      */
     public function testValidateMultipartGreen(string $message) : void
     {
@@ -221,7 +241,7 @@ HTTP
     }
 
     /**
-     * @dataProvider dataProviderRed
+     * @dataProvider dataProviderMultipartRed
      */
     public function testValidateMultipartRed(string $message, string $expectedExceptionClass) : void
     {
@@ -239,5 +259,25 @@ HTTP
 
         $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
         $validator->validate($serverRequest);
+    }
+
+    /**
+     * @dataProvider dataProviderFormUrlencodedGreen
+     */
+    public function testValidateFormUrlencodedGreen(string $message) : void
+    {
+        $specFile = __DIR__ . '/../../stubs/form-url-encoded.yaml';
+
+        $request       = parse_request($message); // convert a text HTTP message to a PSR7 message
+        $serverRequest = new ServerRequest(
+            $request->getMethod(),
+            $request->getUri(),
+            $request->getHeaders(),
+            $request->getBody()
+        );
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($serverRequest);
+        $this->addToAssertionCount(1);
     }
 }

--- a/tests/stubs/api.yaml
+++ b/tests/stubs/api.yaml
@@ -4,7 +4,7 @@ info:
   version: 0.0.1
   contact:
     name: Dmitry Lezhnev
-    url: https://lessthan12ms.com
+    url: https://github.com/lezhnev74/openapi-psr7-validator
     email: lezhnev.work@gmail.com
 paths:
   /read/{param1}/from/{param2}:

--- a/tests/stubs/complete.yaml
+++ b/tests/stubs/complete.yaml
@@ -4,7 +4,7 @@ info:
   version: 0.0.1
   contact:
     name: Dmitry Lezhnev
-    url: https://lessthan12ms.com
+    url: https://github.com/lezhnev74/openapi-psr7-validator
     email: lezhnev.work@gmail.com
 paths:
   /complete/{param1}/{param2}:

--- a/tests/stubs/form-url-encoded.yaml
+++ b/tests/stubs/form-url-encoded.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.2
+info:
+  title: Multipart API
+  version: 0.0.1
+  contact:
+    name: Dmitry Lezhnev
+    url: https://github.com/lezhnev74/openapi-psr7-validator
+    email: lezhnev.work@gmail.com
+paths:
+  /urlencoded/scalar-types:
+    post:
+      summary: Post form-url-encoded body
+      operationId: post-form-url-encoded-body
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                address:
+                  type: string
+
+      responses:
+        204:
+          description: good post

--- a/tests/stubs/multipart.yaml
+++ b/tests/stubs/multipart.yaml
@@ -36,8 +36,8 @@ paths:
           description: good post
   /multipart/files:
     post:
-      summary: Post multipart body with extra properties not defined by schema
-      operationId: post-multipart-body
+      summary: ---
+      operationId: post-multipart-files
       requestBody:
         content:
           multipart/form-data:
@@ -55,8 +55,8 @@ paths:
           description: good post
   /multipart/encoding:
     post:
-      summary: Post multipart body with extra properties not defined by schema
-      operationId: post-multipart-body
+      summary: ---
+      operationId: post-multipart-encoding
       requestBody:
         content:
           multipart/form-data:
@@ -72,10 +72,29 @@ paths:
       responses:
         204:
           description: good post
+  /multipart/encoding/wildcard:
+    post:
+      summary: Post multipart body with wildcard encoding of one part
+      operationId: post-multipart-encoding-wildcard
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                image:
+                  type: string
+                  format: binary
+            encoding:
+              image:
+                contentType: image/*
+      responses:
+        204:
+          description: good post
   /multipart/headers:
     post:
-      summary: Post multipart body with extra properties not defined by schema
-      operationId: post-multipart-body
+      summary: ---
+      operationId: post-multipart-headers
       requestBody:
         content:
           multipart/form-data:

--- a/tests/stubs/multipart.yaml
+++ b/tests/stubs/multipart.yaml
@@ -1,0 +1,98 @@
+openapi: 3.0.2
+info:
+  title: Multipart API
+  version: 0.0.1
+  contact:
+    name: Dmitry Lezhnev
+    url: https://github.com/lezhnev74/openapi-psr7-validator
+    email: lezhnev.work@gmail.com
+paths:
+  /multipart:
+    post:
+      summary: Post multipart body
+      operationId: post-multipart-body
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                id:            # Part 1 (string value)
+                  type: string
+                  format: uuid
+                address:       # Part2 (object)
+                  type: object
+                  properties:
+                    street:
+                      type: string
+                    city:
+                      type: string
+                profileImage:  # Part 3 (an image)
+                  type: string
+                  format: binary
+
+      responses:
+        204:
+          description: good post
+  /multipart/files:
+    post:
+      summary: Post multipart body with extra properties not defined by schema
+      operationId: post-multipart-body
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                filename:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+
+      responses:
+        204:
+          description: good post
+  /multipart/encoding:
+    post:
+      summary: Post multipart body with extra properties not defined by schema
+      operationId: post-multipart-body
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                image:
+                  type: string
+                  format: binary
+            encoding:
+              image:
+                contentType: specific/type
+      responses:
+        204:
+          description: good post
+  /multipart/headers:
+    post:
+      summary: Post multipart body with extra properties not defined by schema
+      operationId: post-multipart-body
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                image:
+                  type: string
+                  format: binary
+            encoding:
+              image:
+                contentType: specific/type
+                headers:
+                  X-Custom-Header:
+                    description: This is a custom header
+                    schema:
+                      type: string
+      responses:
+        204:
+          description: good post

--- a/tests/stubs/multipleMatches.yaml
+++ b/tests/stubs/multipleMatches.yaml
@@ -4,7 +4,7 @@ info:
   version: 0.0.1
   contact:
     name: Dmitry Lezhnev
-    url: https://lessthan12ms.com
+    url: https://github.com/lezhnev74/openapi-psr7-validator
     email: lezhnev.work@gmail.com
 
 paths:

--- a/tests/stubs/pathParams.yaml
+++ b/tests/stubs/pathParams.yaml
@@ -4,7 +4,7 @@ info:
   version: 0.0.1
   contact:
     name: Dmitry Lezhnev
-    url: https://lessthan12ms.com
+    url: https://github.com/lezhnev74/openapi-psr7-validator
     email: lezhnev.work@gmail.com
 
 paths:


### PR DESCRIPTION
#44 

This PR contains logic which validates HTTP message bodies with a multipart content type.

TODO:
- [x] make sure [this PR](https://github.com/Riverline/multipart-parser/pull/28) is merged and retarget composer.json at the original repo
- [x] pass tests at `\OpenAPIValidationTests\PSR7\Validators\BodyValidatorTest`
- [x] check exceptions consistency and clarity for multipart-related errors (added new exception for multipart errors)
- [x] check `application/x-www-form-urlencoded` body validation (limited, see #47)

Changes:
- tests: `\OpenAPIValidationTests\PSR7\Validators\BodyValidatorTest`
- namespace added `OpenAPIValidation\PSR7\Validators\BodyValidator`
- pulled in https://packagist.org/packages/riverline/multipart-parser