### PR TITLE
Add missing dependency webmozart\assert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "respect/validation": "^1.1",
-        "riverline/multipart-parser": "^2.0.3"
+        "riverline/multipart-parser": "^2.0.3",
+        "webmozart/assert": "^1.4"
     },
     "require-dev": {
         "cache/array-adapter": "^1.0",


### PR DESCRIPTION
`Filefactory` uses this package, but it only gets pulled in by phpunit, which is not installed if you run `composer install --no-dev`.