### PR TITLE
#62 remove "smart" casting of parsed params to numerics

### DIFF
--- a/src/PSR7/OperationAddress.php
+++ b/src/PSR7/OperationAddress.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OpenAPIValidation\PSR7;
 
 use OpenAPIValidation\PSR7\Exception\Validation\InvalidPath;
-use function is_numeric;
 use function preg_match;
 use function preg_match_all;
 use function preg_replace;
@@ -91,14 +90,7 @@ class OperationAddress
         // 3. Combine keys and values
         $parsedParams = [];
         foreach ($parameterNames as $name) {
-            $value = $matches[$name];
-
-            // cast numeric
-            if (is_numeric($value)) {
-                $value += 0; // that will cast it properly
-            }
-
-            $parsedParams[$name] = $value;
+            $parsedParams[$name] = $matches[$name];
         }
 
         return $parsedParams;

--- a/tests/PSR7/OperationAddressTest.php
+++ b/tests/PSR7/OperationAddressTest.php
@@ -15,11 +15,11 @@ final class OperationAddressTest extends TestCase
     public function dataProviderParse() : array
     {
         return [
-            ['/users/{id}/group/{group}', '/users/12/group/admin?a=2', ['id' => 12, 'group' => 'admin']],
-            ['/users/{id}', '/users/12?', ['id' => 12]],
-            ['/users/{id}/', '/users/12/', ['id' => 12]],
-            ['/users/{id}/', '/users/22.5/', ['id' => 22.5]],
-            ['/users/{id}/{name}', '/users/22/admin', ['id' => 22, 'name' => 'admin']],
+            ['/users/{id}/group/{group}', '/users/12/group/admin?a=2', ['id' => '12', 'group' => 'admin']],
+            ['/users/{id}', '/users/12?', ['id' => '12']],
+            ['/users/{id}/', '/users/12/', ['id' => '12']],
+            ['/users/{id}/', '/users/22.5/', ['id' => '22.5']],
+            ['/users/{id}/{name}', '/users/22/admin', ['id' => '22', 'name' => 'admin']],
         ];
     }
 

--- a/tests/PSR7/PathParametersTest.php
+++ b/tests/PSR7/PathParametersTest.php
@@ -56,4 +56,17 @@ final class PathParametersTest extends TestCase
         $validator->validate($request);
         $this->addToAssertionCount(1);
     }
+
+    public function testItValidatesParsedIntegersGreen() : void
+    {
+        // In "number/12" an id(12) parsed as a string
+        // The implementation should validate this against `type: integer`
+
+        $specFile = __DIR__ . '/../stubs/pathParams.yaml';
+        $request  = new ServerRequest('get', '/number/99');
+
+        $validator = (new ValidatorBuilder())->fromYamlFile($specFile)->getServerRequestValidator();
+        $validator->validate($request);
+        $this->addToAssertionCount(1);
+    }
 }

--- a/tests/stubs/multipleMatches.yaml
+++ b/tests/stubs/multipleMatches.yaml
@@ -16,6 +16,7 @@ paths:
         required: true
         schema:
           type: string
+          pattern: ^\w+$
     get:
       summary: Read data
       operationId: read

--- a/tests/stubs/pathParams.yaml
+++ b/tests/stubs/pathParams.yaml
@@ -48,3 +48,16 @@ paths:
             text/plain:
               schema:
                 type: string
+  /number/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      summary: Read data
+      operationId: read-int
+      responses:
+        204:
+          description: No response


### PR DESCRIPTION
#62

This PR removes "smart" casting of parsed URL params to numerics:
- URL does not contain type information for serialized values, so parsing cannot reliably tell which PHP type to use for the parsed values. It defaults to "string".
- However, validation against `type` keyword CAN properly detect numerics in strings, see [file](https://github.com/lezhnev74/openapi-psr7-validator/blob/ff4cbbb9e5c4fa5244a1d8bd2b36ad45bb8914e6/src/Schema/Keywords/Type.php#L63)
